### PR TITLE
fix: build in github actions

### DIFF
--- a/.github/workflows/build-library.yml
+++ b/.github/workflows/build-library.yml
@@ -32,6 +32,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
+      - name: Download and rename Godot library package
+        run: |
+          wget https://github.com/godotengine/godot/releases/download/3.5.3-stable/godot-lib.3.5.3.stable.release.aar -O godot-lib.release.aar
+
+      - name: Move Godot library package to the appropriate folder
+        run: mv godot-lib.release.aar godot-lib.release/
+
       - name: Build artifact
         run: ./gradlew :app:assembleRelease
 


### PR DESCRIPTION
- download and rename godot aar library before build

Fixes the following error on GitHub Actions run:

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:compileReleaseKotlin'.
> Could not resolve all files for configuration ':app:releaseCompileClasspath'.
   > Failed to transform godot-lib.release.aar (project :godot-lib.release) to match attributes {artifactType=android-classes-jar, org.gradle.usage=java-api}.
      > Execution failed for IdentityTransform: /home/runner/work/godot-google-play-game-services-android-plugin/godot-google-play-game-services-android-plugin/godot-lib.release/godot-lib.release.aar.
         > File/directory does not exist: /home/runner/work/godot-google-play-game-services-android-plugin/godot-google-play-game-services-android-plugin/godot-lib.release/godot-lib.release.aar

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org/

BUILD FAILED in 40s
18 actionable tasks: 18 executed
Error: Process completed with exit code 1.
```