### PR TITLE
Fix crash due to null image Uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ In short follow these steps:
     - Linux:
       - `./gradlew assembleRelease`
   - Copy the newly created `.aar` file to your plugin directory:
-    - `app/build/outputs/aar/GodotPlayGamesServices.release.aar` to `[your Godot project]/android/plugins/`
+    - `app/build/outputs/aar/GodotGooglePlayGameServices.release.aar` to `[your Godot project]/android/plugins/`
 
 # How to use
 

--- a/app/src/main/java/com/jacobibanez/godot/gpgs/games/GameMapper.kt
+++ b/app/src/main/java/com/jacobibanez/godot/gpgs/games/GameMapper.kt
@@ -17,22 +17,16 @@ fun fromGame(godot: Godot, game: Game) = Dictionary().apply {
     game.secondaryCategory.let { put("secondaryCategory", it) }
     put("themeColor", game.themeColor)
     put("hasGamepadSupport", game.hasGamepadSupport())
-    game.hiResImageUri.let {
-        put(
-            "hiResImageUri",
-            it.toStringAndSave(godot, "hiResImageUri", game.applicationId)
-        )
-    }
-    game.iconImageUri.let {
-        put(
-            "iconImageUri",
-            it.toStringAndSave(godot, "iconImageUri", game.applicationId)
-        )
-    }
-    game.featuredImageUri.let {
-        put(
-            "featuredImageUri",
-            it.toStringAndSave(godot, "featuredImageUri", game.applicationId)
-        )
-    }
+    put(
+        "hiResImageUri",
+        game.hiResImageUri?.toStringAndSave(godot, "hiResImageUri", game.applicationId) ?: ""
+    )
+    put(
+        "iconImageUri",
+        game.iconImageUri?.toStringAndSave(godot, "iconImageUri", game.applicationId) ?: ""
+    )
+    put(
+        "featuredImageUri",
+        game.featuredImageUri?.toStringAndSave(godot, "featuredImageUri", game.applicationId) ?: ""
+    )
 }


### PR DESCRIPTION
⚠️ **This is a hotfix!** ⚠️

While loading an snapshot on a new player account, the game crashed.

I found out that some `Uri`s such as `game.hiResImageUri` sometimes may be returned as `null`, causing the game to crash.
This PR checks if they are `null` before calling `toStringAndSave` on them.

Binaries: [GodotGooglePlayGameServices.zip](https://github.com/Iakobs/godot-google-play-game-services-android-plugin/files/14002207/GodotGooglePlayGameServices.zip)
