### PR TITLE
Backported `loadTopScores` and `loadPlayerCenteredScores` 

### DIFF
--- a/app/src/main/java/com/jacobibanez/godot/gpgs/GodotGooglePlayGameServices.kt
+++ b/app/src/main/java/com/jacobibanez/godot/gpgs/GodotGooglePlayGameServices.kt
@@ -115,6 +115,15 @@ class GodotGooglePlayGameServices(
     fun leaderboardsLoad(leaderboardId: String, forceReload: Boolean) =
         leaderboardsProxy.load(leaderboardId, forceReload)
 
+    @UsedByGodot
+    fun leaderboardsLoadPlayerCenteredScores(leaderboardId: String, timeSpan: Int, collection: Int, maxResults: Int, forceReload: Boolean) =
+        leaderboardsProxy.loadPlayerCenteredScores(leaderboardId, timeSpan, collection, maxResults, forceReload)
+
+    @UsedByGodot
+    fun leaderboardsLoadTopScores(leaderboardId: String, timeSpan: Int, collection: Int, maxResults: Int, forceReload: Boolean) =
+        leaderboardsProxy.loadTopScores(leaderboardId, timeSpan, collection, maxResults, forceReload)
+
+
     /* Players */
     @UsedByGodot
     fun playersCompareProfile(otherPlayerId: String) = playersProxy.playersCompareProfile(otherPlayerId)

--- a/app/src/main/java/com/jacobibanez/godot/gpgs/leaderboards/LeaderboardMapper.kt
+++ b/app/src/main/java/com/jacobibanez/godot/gpgs/leaderboards/LeaderboardMapper.kt
@@ -1,5 +1,6 @@
 package com.jacobibanez.godot.gpgs.leaderboards
 
+import com.google.android.gms.games.LeaderboardsClient
 import com.google.android.gms.games.leaderboard.Leaderboard
 import com.google.android.gms.games.leaderboard.LeaderboardScore
 import com.google.android.gms.games.leaderboard.LeaderboardVariant
@@ -73,3 +74,10 @@ fun fromLeaderboardVariant(variants: ArrayList<LeaderboardVariant>): List<Dictio
             put("hasPlayerInfo", variant.hasPlayerInfo())
         }
     }.toList()
+
+/** @suppress */
+fun fromLeaderboardScores(godot: Godot, scores: LeaderboardsClient.LeaderboardScores) = Dictionary().apply {
+    put("leaderboard", fromLeaderboard(godot, scores.leaderboard!!))
+    val scoresMapped = scores.scores.map { fromLeaderboardScore(godot, it) }.toList()
+    put("scores", scoresMapped)
+}

--- a/app/src/main/java/com/jacobibanez/godot/gpgs/leaderboards/LeaderboardsProxy.kt
+++ b/app/src/main/java/com/jacobibanez/godot/gpgs/leaderboards/LeaderboardsProxy.kt
@@ -9,6 +9,8 @@ import com.google.gson.Gson
 import com.jacobibanez.godot.gpgs.PLUGIN_NAME
 import com.jacobibanez.godot.gpgs.signals.LeaderboardSignals.leaderboardsAllLoaded
 import com.jacobibanez.godot.gpgs.signals.LeaderboardSignals.leaderboardsLoaded
+import com.jacobibanez.godot.gpgs.signals.LeaderboardSignals.leaderboardsPlayerCenteredScoresLoaded
+import com.jacobibanez.godot.gpgs.signals.LeaderboardSignals.leaderboardsTopScoresLoaded
 import com.jacobibanez.godot.gpgs.signals.LeaderboardSignals.leaderboardsScoreLoaded
 import com.jacobibanez.godot.gpgs.signals.LeaderboardSignals.leaderboardsScoreSubmitted
 import org.godotengine.godot.Dictionary
@@ -220,4 +222,98 @@ class LeaderboardsProxy(
                 }
             }
     }
+
+    fun loadPlayerCenteredScores(
+        leaderboardId: String,
+        timeSpan: Int,
+        collection: Int,
+        maxResults: Int,
+        forceReload: Boolean
+    ) {
+        Log.d(
+            tag, "Loading player centered scores for leaderboard $leaderboardId, " +
+                    "span ${TimeSpan.fromSpan(timeSpan)?.name}, collection " +
+                    "${Collection.fromType(collection)?.name} and max results $maxResults"
+        )
+        leaderboardsClient.loadPlayerCenteredScores(leaderboardId, timeSpan, collection, maxResults, forceReload)
+            .addOnCompleteListener { task ->
+                if (task.isSuccessful) {
+                    Log.d(
+                        tag,
+                        "Player centered scores loaded successfully. Data is stale? ${task.result.isStale}"
+                    )
+                    val leaderboardScores = task.result.get()!!
+                    val result: Dictionary = fromLeaderboardScores(godot, leaderboardScores)
+                    leaderboardScores.release()
+                    emitSignal(
+                        godot,
+                        PLUGIN_NAME,
+                        leaderboardsPlayerCenteredScoresLoaded,
+                        leaderboardId,
+                        Gson().toJson(result)
+                    )
+                } else {
+                    Log.e(
+                        tag,
+                        "Failed to load player centered scores. Cause: ${task.exception}",
+                        task.exception
+                    )
+                    emitSignal(
+                        godot,
+                        PLUGIN_NAME,
+                        leaderboardsPlayerCenteredScoresLoaded,
+                        leaderboardId,
+                        Gson().toJson(null)
+                    )
+                }
+            }
+    }
+
+    fun loadTopScores(
+        leaderboardId: String,
+        timeSpan: Int,
+        collection: Int,
+        maxResults: Int,
+        forceReload: Boolean
+    ) {
+        Log.d(
+            tag, "Loading top scores for leaderboard $leaderboardId, " +
+                    "span ${TimeSpan.fromSpan(timeSpan)?.name}, collection " +
+                    "${Collection.fromType(collection)?.name} and max results $maxResults"
+        )
+        leaderboardsClient.loadTopScores(leaderboardId, timeSpan, collection, maxResults, forceReload)
+            .addOnCompleteListener { task ->
+                if (task.isSuccessful) {
+                    Log.d(
+                        tag,
+                        "Top scores loaded successfully. Data is stale? ${task.result.isStale}"
+                    )
+                    val leaderboardScores = task.result.get()!!
+                    val result: Dictionary = fromLeaderboardScores(godot, leaderboardScores)
+                    leaderboardScores.release()
+                    emitSignal(
+                        godot,
+                        PLUGIN_NAME,
+                        leaderboardsTopScoresLoaded,
+                        leaderboardId,
+                        Gson().toJson(result)
+                    )
+                } else {
+                    Log.e(
+                        tag,
+                        "Failed to load top scores. Cause: ${task.exception}",
+                        task.exception
+                    )
+                    emitSignal(
+                        godot,
+                        PLUGIN_NAME,
+                        leaderboardsTopScoresLoaded,
+                        leaderboardId,
+                        Gson().toJson(null)
+                    )
+                }
+            }
+    }
+
+
 }

--- a/app/src/main/java/com/jacobibanez/godot/gpgs/signals/Signals.kt
+++ b/app/src/main/java/com/jacobibanez/godot/gpgs/signals/Signals.kt
@@ -15,6 +15,8 @@ fun getSignals(): MutableSet<SignalInfo> = mutableSetOf(
     LeaderboardSignals.leaderboardsScoreLoaded,
     LeaderboardSignals.leaderboardsAllLoaded,
     LeaderboardSignals.leaderboardsLoaded,
+    LeaderboardSignals.leaderboardsPlayerCenteredScoresLoaded,
+    LeaderboardSignals.leaderboardsTopScoresLoaded,
 
     PlayerSignals.playersCurrentLoaded,
     PlayerSignals.playersFriendsLoaded,
@@ -115,6 +117,22 @@ object LeaderboardSignals {
      * @return A JSON with a [com.google.android.gms.games.leaderboard.Leaderboard](https://developers.google.com/android/reference/com/google/android/gms/games/leaderboard/Leaderboard).
      */
     val leaderboardsLoaded = SignalInfo("leaderboardsLoaded", String::class.java)
+
+    /**
+     * This signal is emitted when calling the [com.jacobibanez.godot.gpgs.GodotGooglePlayGameServices.leaderboardsLoadPlayerCenteredScores] method.
+     *
+     * @return The leaderboard id and a JSON with a [com.google.android.gms.games.LeaderboardsClient.LeaderboardScores](https://developers.google.com/android/reference/com/google/android/gms/games/LeaderboardsClient.LeaderboardScores).
+     */
+    val leaderboardsPlayerCenteredScoresLoaded =
+        SignalInfo("leaderboardsPlayerCenteredScoresLoaded", String::class.java, String::class.java)
+
+    /**
+     * This signal is emitted when calling the [com.jacobibanez.godot.gpgs.GodotGooglePlayGameServices.leaderboardsLoadTopScores] method.
+     *
+     * @return The leaderboard id and a JSON with a [com.google.android.gms.games.LeaderboardsClient.LeaderboardScores](https://developers.google.com/android/reference/com/google/android/gms/games/LeaderboardsClient.LeaderboardScores).
+     */
+    val leaderboardsTopScoresLoaded =
+        SignalInfo("leaderboardsTopScoresLoaded", String::class.java, String::class.java)
 }
 
 /**


### PR DESCRIPTION
- Backported `loadTopScores()` and `loadPlayerCenteredScores()` methods from the [4.2 repo](https://github.com/Iakobs/godot-play-game-services).
- Added the necessary new signals
- Adjusted the method and signal names to match the existing naming style.
- Tested, and can confirm, it works like a charm. :)